### PR TITLE
[EASY] 13 / 4 / 7 / 11 문제 풀이

### DIFF
--- a/questions/00004-easy-pick/template.ts
+++ b/questions/00004-easy-pick/template.ts
@@ -1,1 +1,3 @@
-type MyPick<T, K> = any
+type MyPick<T, K extends keyof T> = {
+  [key in K]: T[key]
+}

--- a/questions/00007-easy-readonly/template.ts
+++ b/questions/00007-easy-readonly/template.ts
@@ -1,1 +1,3 @@
-type MyReadonly<T> = any
+type MyReadonly<T> = {
+  readonly [key in keyof T]: T[key]
+}

--- a/questions/00011-easy-tuple-to-object/template.ts
+++ b/questions/00011-easy-tuple-to-object/template.ts
@@ -1,1 +1,3 @@
-type TupleToObject<T extends readonly any[]> = any
+type TupleToObject<T extends readonly any[]> = {
+  [key in T[number]]: key
+}

--- a/questions/00011-easy-tuple-to-object/template.ts
+++ b/questions/00011-easy-tuple-to-object/template.ts
@@ -1,3 +1,3 @@
-type TupleToObject<T extends readonly any[]> = {
+type TupleToObject<T extends readonly (string | number | symbol)[]> = {
   [key in T[number]]: key
 }

--- a/questions/00013-warm-hello-world/template.ts
+++ b/questions/00013-warm-hello-world/template.ts
@@ -1,1 +1,1 @@
-type HelloWorld = any // expected to be a string
+type HelloWorld = string // expected to be a string


### PR DESCRIPTION
## 13. 아래의 코드를 변경해서 테스트 코드를 통과하세요. (타입 체크 에러 없음).
`type HelloWorld = string`
## 4. `T`에서 `K` 프로퍼티만 선택해 새로운 오브젝트 타입을 만드는 내장 제네릭 `Pick<T, K>`을 이를 사용하지 않고 구현하세요.
- 코드
`type MyPick<T, K extends keyof T> = {
  [key in K]: T[key]
}`
- 풀이
K는 T의 키들의 부분집합으로, 새로운 오브젝트 타입의 key는 K의 각 프로퍼티를 순회하고, T에서 key 프로퍼티의 타입만 가져온다.
## 7. `T`의 모든 프로퍼티를 읽기 전용(재할당 불가)으로 바꾸는 내장 제네릭 `Readonly<T>`를 이를 사용하지 않고 구현하세요.
- 코드
`type MyReadonly<T> = {
  readonly [Key in keyof T] : T[Key]
}`
- 풀이
keyof T는 T타입의 모든 프로퍼티 키를 유니온 타입으로 가져오고, Key는 모든 프로퍼티를 순회한다. 각 속성 앞에 readonly 수식어를 붙여 읽기 전용으로 만들고, T[Key]로 T에서 Key 프로퍼티의 타입을 가져온다. Key는 T의 모든 프로퍼티를 순회하니 원래 타입을 유지한다는 의미이기도 하다.
## 11. 배열(튜플)을 받아, 각 원소의 값을 key/value로 갖는 오브젝트 타입을 반환하는 타입을 구현하세요.
- 코드
`type TupleToObject<T extends readonly any[]> = { [P in T[number]]: P }`
- 풀이
T는 배열(튜플)을 받고, T[number]는 T의 모든 요소를 유니온 타입으로 받는다. P는 T에서 추출한 리터럴 타입이고, 이를 key로 가진다.
in을 사용해 T의 모든 요소를 객체의 key로 사용하고, value도 key와 동일한 값을 가지게 한다.