### PR TITLE
[EASY] 14 / 18 / 43 문제 풀이

### DIFF
--- a/questions/00014-easy-first/template.ts
+++ b/questions/00014-easy-first/template.ts
@@ -1,1 +1,1 @@
-type First<T extends any[]> = any
+type First<T extends any[]> = T extends [] ? never : T[0]

--- a/questions/00018-easy-tuple-length/template.ts
+++ b/questions/00018-easy-tuple-length/template.ts
@@ -1,1 +1,1 @@
-type Length<T> = any
+type Length<T extends readonly any[]> = T['length']

--- a/questions/00043-easy-exclude/template.ts
+++ b/questions/00043-easy-exclude/template.ts
@@ -1,1 +1,1 @@
-type MyExclude<T, U> = any
+type MyExclude<T, U> = T extends U ? never : T


### PR DESCRIPTION
## 14. 배열(튜플) T를 받아 첫 원소의 타입을 반환하는 제네릭 First<T>를 구현하세요.
- 코드
`type First<T extends any[]> = T extends [] ? never : T[0]`
- 풀이
T extends []는 빈 배열을 확인할 수 있는 조건으로, 빈 배열 일 때 never를 반환하고, 아닐 때 T의 첫 원소 타입을 반환합니다.
## 18. 배열(튜플)을 받아 길이를 반환하는 제네릭 `Length<T>`를 구현하세요.
- 코드
`type Length<T extends readonly any[]> = T['length']`
- 풀이
T는 배열(튜플)을 받는데, 배열의 프로퍼티로 length에 접근할 수 있습니다. T.length는 런타임에서 사용하는 방식이라 컴파일 타임에 타입을 검사하는 TS에선 사용할 수 없습니다. readonly 배열을 받게 한 이유는 테스트 케이스에 as const가 있어 해당 배열이 리터럴 타입으로 고정되고, 읽기 전용 배열이 되기 때문입니다.
## 43. T에서 U에 할당할 수 있는 타입을 제외하는 내장 제네릭 Exclude<T, U>를 이를 사용하지 않고 구현하세요.
- 코드
`type MyExclude<T, U> = T extends U ? never : T`
- 풀이
T를 U에 할당할 수 있으면(=T가 U의 서브타입이면) never를 반환하고, 할당할 수 없으면 T를 반환합니다.