### PR TITLE
[EASY] 189 / 268 / 533

### DIFF
--- a/questions/00189-easy-awaited/template.ts
+++ b/questions/00189-easy-awaited/template.ts
@@ -1,1 +1,5 @@
-type MyAwaited<T> = any
+type MyAwaited<T extends PromiseLike<any>> = T extends PromiseLike<infer U>
+  ? U extends PromiseLike<any>
+    ? MyAwaited<U>
+    : U
+  : never

--- a/questions/00268-easy-if/template.ts
+++ b/questions/00268-easy-if/template.ts
@@ -1,1 +1,1 @@
-type If<C, T, F> = any
+type If<C extends boolean, T, F> = C extends true ? T : F

--- a/questions/00533-easy-concat/template.ts
+++ b/questions/00533-easy-concat/template.ts
@@ -1,1 +1,1 @@
-type Concat<T, U> = any
+type Concat<T extends readonly any[], U extends readonly any[]> = [...T, ...U]


### PR DESCRIPTION
## 189. Promise와 같은 타입에 감싸인 타입이 있을 때, 안에 감싸인 타입이 무엇인지 어떻게 알 수 있을까요?
**예시**: `Promise<ExampleType>`이 있을 때, `ExampleType`을 어떻게 얻을 수 있을까요?
**코드**
```javascript
type MyAwaited<T extends PromiseLike<any>> = T extends PromiseLike<infer U>
  ? U extends PromiseLike<any>
  ? MyAwaited<U>
  : U
  : never;
```
**풀이**
1. Promise 타입은 Promise 객체를 타입으로 표현한 TS 내장 타입으로, 비동기 작업의 결과를 나타내며 비동기 작업 완료 후 성공 또는 실패 상태를 반환합니다.
2. PromiseLike<T>는 then 메서드를 가진 모든 객체를 포함하는 Promise보다 넓은 범위의 타입입니다.
3. T가 유사프로미스객체 타입이라면 내부 타입을 U로 추론합니다. 조건문에 거짓이면 never를 반환하고, 참이면 U가 유사프로미스객체인지 확인합니다. U가 유사 프로미스 객체이면 MyAwaited를 재귀적으로 호출해 내부 타입을 추출하고, 아니라면 최종적으로 U를 반환합니다.

## 268. 조건 `C`, 참일 때 반환하는 타입 `T`, 거짓일 때 반환하는 타입 `F`를 받는 타입 `If`를 구현하세요. `C`는 `true` 또는 `false`이고, `T`와 `F`는 아무 타입입니다.
**코드**: `type If<C extends boolean, T, F> = C extends true ? T : F`
**풀이**: C는 boolean 타입을 받게 하고, 조건문으로 true를 받을 때와 아닐 때를 나누면 됩니다

## 533. JavaScript의 Array.concat 함수를 타입 시스템에서 구현하세요. 타입은 두 인수를 받고, 인수를 왼쪽부터 concat한 새로운 배열을 반환해야 합니다.
**코드**: `type Concat<T extends readonly any[], U extends readonly any[]> = [...T, ...U];`
**풀이**: 튜플이 존재하기 때문에 readonly any[]로 확장한 T를 사용했습니다. 배열을 결합하는 타입은 스프레드 문법을 사용할 수 있습니다.
**알게된 점**
처음엔 아래 코드로 작성했습니다
`type Concat<T extends any[], U extends any[]> = [P in keyof T | P in keyof U]`
근데 배열에 keyof를 쓰면 인덱스가 반환되는 것이더라고요! 배열의 키는 항상 숫자로 된 인덱스 이기 때문입니다.