### PR TITLE
[EASY] 898 / 3057 / 3060

### DIFF
--- a/questions/00898-easy-includes/template.ts
+++ b/questions/00898-easy-includes/template.ts
@@ -1,1 +1,7 @@
-type Includes<T extends readonly any[], U> = any
+import type { Equal } from '@type-challenges/utils'
+
+type Includes<T extends readonly any[], U> = T extends [infer First, ...infer Rest]
+  ? Equal<First, U> extends true
+    ? true
+    : Includes<Rest, U>
+  : false

--- a/questions/03057-easy-push/template.ts
+++ b/questions/03057-easy-push/template.ts
@@ -1,1 +1,1 @@
-type Push<T, U> = any
+type Push<T extends any[], U> = [...T, U]

--- a/questions/03060-easy-unshift/template.ts
+++ b/questions/03060-easy-unshift/template.ts
@@ -1,1 +1,1 @@
-type Unshift<T, U> = any
+type Unshift<T extends any[], U> = [U, ...T]


### PR DESCRIPTION
## 898. JavaScript의 Array.includes 함수를 타입 시스템에서 구현하세요. 타입은 두 인수를 받고, true 또는 false를 반환해야 합니다.
- **코드**
`type Includes<T extends readonly any[], U> = T extends [infer First, ...infer Rest] ? U extends T ? 
  Equal<First, U> extends true
    ? true
    : Includes<Rest, U>
  : false`
- **풀이**
T extends [infer First, ...infer Rest]는 T가 최소 하나의 요소를 가진 배열인가를 확인하고 맞다면 첫 번째 요소 타입을 First로, 나머지 요소들의 타입을 Rest로 추론합니다. U가 T타입을 받으면 Equal 유틸리티 타입을 활용해 First가 U와 같은 타입인지 확인하고 같은 타입이면 true, 같은 타입이 아니면 Rest를 같은 방식으로 확인합니다.

## 3057. Array.push의 제네릭 버전을 구현하세요.
- **코드**: `type Push<T extends any[], U> = [...T, U]`
- **풀이**: T는 배열 타입을 받고, 스프레드 문법을 사용해 T배열의 마지막 요소로 U를 추가합니다.

## 3060. `Array.unshift`의 타입 버전을 구현하세요.
- **코드**: `type Unshift<T extends any[], U> = [U, ...T]`
- **풀이**: 스프레드 문법을 사용해 배열 0번째 인덱스로 U를 추가하게 구현합니다.