### PR TITLE
[EASY] 3312

### DIFF
--- a/questions/03312-easy-parameters/template.ts
+++ b/questions/03312-easy-parameters/template.ts
@@ -1,1 +1,1 @@
-type MyParameters<T extends (...args: any[]) => any> = any
+type MyParameters<T extends (...args: any[]) => any> = T extends (...args: infer S) => any ? S : never


### PR DESCRIPTION
## 3312. 내장 제네릭 `Parameters<T>`를 이를 사용하지 않고 구현하세요.
- **코드**: `type MyParameters<T extends (...args: any[]) => any> = T extends (...args: infer S) => any ? S : never`
- **풀이**
우선, Parameters 내장 제네릭 타입은 함수 타입 T의 매개변수 타입들의 튜플 타입을 구성합니다.
T는 함수 타입을 받으면 매개변수가 S로 추론될 때 S를 반환하고, 아니면 never를 반환합니다.
...args로 매개변수 타입을 쓰면 매개변수 개수와 타입을 제한하지 않는 함수를 나타냅니다.