### PR TITLE
[MEDIUM] 2 / 3 / 8 / 9 / 10 / 12

### DIFF
--- a/questions/00002-medium-return-type/template.ts
+++ b/questions/00002-medium-return-type/template.ts
@@ -1,1 +1,1 @@
-type MyReturnType<T> = any
+type MyReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R ? R : never

--- a/questions/00003-medium-omit/template.ts
+++ b/questions/00003-medium-omit/template.ts
@@ -1,1 +1,3 @@
-type MyOmit<T, K> = any
+type MyOmit<T, K extends keyof T> = {
+  [P in keyof T as P extends K ? never : P]: T[P]
+}

--- a/questions/00008-medium-readonly-2/template.ts
+++ b/questions/00008-medium-readonly-2/template.ts
@@ -1,1 +1,2 @@
-type MyReadonly2<T, K> = any
+type MyReadonly2<T, K extends keyof T = keyof T> =
+  { readonly [P in K]: T[P] } & { [P in keyof T as P extends K ? never : P]: T[P] }

--- a/questions/00009-medium-deep-readonly/template.ts
+++ b/questions/00009-medium-deep-readonly/template.ts
@@ -1,7 +1,7 @@
 type DeepReadonly<T> =
   { readonly [K in keyof T]: T[K] extends (...args: any) => any
     ? T[K]
-    : T[K] extends { [k in string]: any }
+    : T[K] extends Record<any, any>
       ? DeepReadonly<T[K]>
       : T[K]
   }

--- a/questions/00009-medium-deep-readonly/template.ts
+++ b/questions/00009-medium-deep-readonly/template.ts
@@ -1,1 +1,7 @@
-type DeepReadonly<T> = any
+type DeepReadonly<T> =
+  { readonly [K in keyof T]: T[K] extends (...args: any) => any
+    ? T[K]
+    : T[K] extends { [k in string]: any }
+      ? DeepReadonly<T[K]>
+      : T[K]
+  }

--- a/questions/00010-medium-tuple-to-union/template.ts
+++ b/questions/00010-medium-tuple-to-union/template.ts
@@ -1,1 +1,1 @@
-type TupleToUnion<T> = any
+type TupleToUnion<T extends any[]> = T[number]

--- a/questions/00012-medium-chainable-options/template.ts
+++ b/questions/00012-medium-chainable-options/template.ts
@@ -1,4 +1,4 @@
-type Chainable = {
-  option(key: string, value: any): any
-  get(): any
+type Chainable<R = {}> = {
+  option<K extends string, V>(key: K extends keyof R ? never : K, value: V): Chainable<Omit<R, K> & Record<K, V>>
+  get(): R
 }


### PR DESCRIPTION
## 2. 내장 제네릭 ReturnType<T>을 이를 사용하지 않고 구현하세요.
**코드**
`type MyReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R ? R : never`
**풀이**
1. 제네릭 T는 함수 타입을 받습니다.
2. T의 반환 타입이 R로 추론될 때 R을 반환하고, 아니면 never를 반환합니다.
**고민**
이 문제를 풀면서 <T extends Function>과 <T extends (…args: any) ⇒ any>의 차이가 궁금했습니다.
<T extends Function> 는 매개변수 타입을 보장하지 않고, 반환 타입 추론도 어려워 타입 추론에 적합하지 않다고 합니다. 광범위하기도 하고요.
<T extends (…args: any) ⇒ any> 는 반환 타입 추론이 가능하고, 매개변수까지 포함된 정확한 함수 타입을 제한할 수 있어 제네릭에서 함수 타입을 다룰 때 더 적합하다고 합니다.
## 3. T에서 K 프로퍼티만 제거해 새로운 오브젝트 타입을 만드는 내장 제네릭 Omit<T, K>를 이를 사용하지 않고 구현하세요.
**코드**
`type MyOmit<T, K extends keyof T> = {
  [P in keyof T as P extends K ? never : P] : T[P]
}`
**풀이**
1. K는 T의 키들의 부분집합입니다.
2. P는 T의 키들의 부분집합인데, `as P extends K ? never : P`를 사용해 K에 해당하는 키를 never로 만들어 제거했습니다.
## 8. T에서 K 프로퍼티만 읽기 전용으로 설정해 새로운 오브젝트 타입을 만드는 제네릭 MyReadonly2<T, K>를 구현하세요. K가 주어지지 않으면 단순히 Readonly<T>처럼 모든 프로퍼티를 읽기 전용으로 설정해야 합니다.
**코드**
`type MyReadonly2<T, K extends keyof T = keyof T> = 
	{ readonly [P in K]: T[P] } & { [P in keyof T as P extends K ? never : P]: T[P] }`
**풀이**
1. K의 기본값을 keyof T로 설정합니다.
2. K를 순회하며 프로퍼티를 readonly로 설정하되 K를 제외한 프로퍼티는 그대로 둡니다.
## 9. 객체의 프로퍼티와 모든 하위 객체를 재귀적으로 읽기 전용으로 설정하는 제네릭 `DeepReadonly<T>`를 구현하세요.
이 챌린지에서는 타입 파라미터 `T`를 객체 타입으로 제한하고 있습니다. 객체뿐만 아니라 배열, 함수, 클래스 등 가능한 다양한 형태의 타입 파라미터를 사용하도록 도전해 보세요.
**코드**
`type DeepReadonly<T> =
  { readonly [K in keyof T]: T[K] extends (...args: any) => any
    ? T[K]
    : T[K] extends Record <any, any>
      ? DeepReadonly<T[K]>
      : T[K]
  }`
**풀이**
1. 우선 모든 프로퍼티를 readonly로 만듭니다.
2. 조건문을 함수를 받을 때와 객체를 받을 때로 나누고, 함수를 받을 땐 T[K]를 반환합니다.
3. 객체를 받을 땐 재귀 탐색합니다.
4. 함수도, 객체도 아닐 땐(원시타입 등) T[K]를 반환합니다.
## 10. 튜플 값으로 유니온 타입을 생성하는 제네릭 TupleToUnion<T>를 구현하세요.
**코드**
`type TupleToUnion<T extends any[]> = T[number]`
**풀이**
T[number]가 튜플 또는 배열의 모든 요소를 유니온 타입으로 추출합니다.
## 12. 체인 가능 옵션은 일반적으로 Javascript에서 사용됩니다. 하지만 TypeScript로 전환하면 제대로 구현할 수 있나요?

이 챌린지에서는 `option(key, value)`과 `get()` 두가지 함수를 제공하는 객체(또는 클래스) 타입을 구현해야 합니다. 현재 타입을 `option`으로 지정된 키와 값으로 확장할 수 있고 `get`으로 최종 결과를 가져올 수 있어야 합니다.

문제를 해결하기 위해 js/ts 로직을 작성할 필요는 없습니다. 단지 타입 수준입니다.

`key`는 `string`만 허용하고 `value`는 무엇이든 될 수 있다고 가정합니다. 같은 `key`는 두 번 전달되지 않습니다.
**코드**
`type Chainable<R = {}> = {
option<K extends string, V>(key: K extends keyof R ? never : K, value: V): Chainable<Omit<R, K> & Record<K, V>>
get(): R
}`
**풀이**
1. key가 R의 부분집합이면 never로 제외하고, 아니면 K를 반환합니다.
2. 체이닝을 하기 위해선 같은 객체여야 하기 때문에 Chainable 타입을 반환하고, Omit으로 R 중 K를 제거하고, 새로운 객체 K-V를 추가합니다.