### PR TITLE
[MEDIUM] 15 / 116 / 531

### DIFF
--- a/questions/00015-medium-last/template.ts
+++ b/questions/00015-medium-last/template.ts
@@ -1,1 +1,1 @@
-type Last<T extends any[]> = any
+type Last<T extends any[]> = T extends [...any[], infer L] ? L : never

--- a/questions/00116-medium-replace/template.ts
+++ b/questions/00116-medium-replace/template.ts
@@ -1,1 +1,5 @@
-type Replace<S extends string, From extends string, To extends string> = any
+type Replace<S extends string, From extends string, To extends string> =
+  S extends '' ? S
+    : S extends `${infer V}${From}${infer R}`
+      ? `${V}${To}${R}`
+      : S

--- a/questions/00531-medium-string-to-union/template.ts
+++ b/questions/00531-medium-string-to-union/template.ts
@@ -1,1 +1,1 @@
-type StringToUnion<T extends string> = any
+type StringToUnion<T extends string> = T extends `${infer First}${infer Rest}` ? First | StringToUnion<Rest> : never


### PR DESCRIPTION
## 15. 배열 T를 사용하고 마지막 요소를 반환하는 제네릭 Last<T>를 구현합니다.
**코드**
`type Last<T extends any[]> = T extends [...any[], infer L] ? L : never`
**풀이**
1. T가 마지막 요소 L로 추론되는 배열을 받을 때 L을 반환하고, 아니면 never를 반환합니다.
## 116. 문자열 S에서 From를 찾아 한 번만 To로 교체하는 Replace<S, From, To>를 구현하세요.
**코드**
`type Replace<S extends string, From extends string, To extends string> = From extends ""
  ? S
  : S extends `${infer A}${From}${infer B}`
	  ? `${A}${To}${B}`
	  : S;`
**풀이**
1. 문자열을 부분으로 나누고 infer 키워드로 각 부분을 변수처럼 사용할 수 있습니다.
## 531.  문자열 인수를 입력받는 String to Union 유형을 구현하세요. 출력은 입력 문자열의 Union Type이어야 합니다.
**코드**
`type StringToUnion<T extends string> =
T extends `${infer First}${infer Rest}`
? First | StringToUnion<Rest> : never`
**풀이**
1. T 문자열을 infer을 사용해 한 글자씩 분해한다.
2. 재귀를 돌리면서 한 글자씩 분해한 문자들을 유니온 타입으로 만든다.
3. 남은 문자가 없으면 never를 반환한다.